### PR TITLE
Put and delete requests in native driver

### DIFF
--- a/classes/kohana/functest/driver/native.php
+++ b/classes/kohana/functest/driver/native.php
@@ -92,6 +92,16 @@ class Kohana_FuncTest_Driver_Native extends FuncTest_Driver {
 		return $this->request(Request::POST, $uri, $query, $post, $files);
 	}
 
+	public function put($uri, array $query = array(), array $payload = array(), array $files = array())
+	{
+		return $this->request(Request::PUT, $uri, $query, $payload, $files);
+	}
+
+	public function delete($uri, array $query = array())
+	{
+		return $this->request(Request::DELETE, $uri, $query);
+	}
+
 	public function request($type, $uri, array $query = array(), array $post = array(), array $files = array())
 	{
 		$this->response = Response::factory();


### PR DESCRIPTION
The native driver did not have neither `PUT` nor `DELETE` requests despite stating that in the documentation.
